### PR TITLE
Add Claude settings symlink to makesymlink.sh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,7 @@
       "Bash(curl:*)",
       "Bash(wget:*)",
       "Bash(nc:*)",
+      "Bash(chown:*)",
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,63 @@
-/Users/hisahiro.tsukamoto/github/hihats/dotfiles/.claude/settings.json
+{
+  "disableBypassPermissionsMode": "disable",
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(cp:*)",
+      "Bash(mkdir:*)",
+      "Bash(echo:*)",
+      "Bash(cat:*)",
+      "Bash(find:*)",
+      "Bash(jq:*)",
+      "Bash(git add:*)",
+      "Bash(git pull:*)",
+      "Bash(git switch:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh search issues:*)",
+      "Bash(gh issue view:*)",
+      "Bash(claude mcp:*)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:github.com)"
+    ],
+    "deny": [
+      "_description: 特定のファイル操作を全て禁止",
+      "Read(.env*)", "Edit(.env*)", "Write(.env*)", "Bash(*:.env*)",
+      "Read(**/.env*)", "Edit(**/.env*)", "Write(**/.env*)", "Bash(*:**/.env*)",
+      "Read(.credential*)", "Edit(.credential*)", "Write(.credential*)", "Bash(*:.credential*)",
+      "Read(*.credential*)", "Edit(*.credential*)", "Write(*.credential*)", "Bash(*:*.credential*)",
+      "Read(**/.credential*)", "Edit(**/.credential*)", "Write(**/.credential*)", "Bash(*:**/.credential*)",
+      "Read(**/*.credential*)", "Edit(**/*.credential*)", "Write(**/*.credential*)", "Bash(*:**/*.credential*)",
+      "Read(.secret*)", "Edit(.secret*)", "Write(.secret*)", "Bash(*:.secret*)",
+      "Read(*.secret*)", "Edit(*.secret*)", "Write(*.secret*)", "Bash(*:*.secret*)",
+      "Read(**/.secret*)", "Edit(**/.secret*)", "Write(**/.secret*)", "Bash(*:**/.secret*)",
+      "Read(**/*.secret*)", "Edit(**/*.secret*)", "Write(**/*.secret*)", "Bash(*:**/*.secret*)",
+      "Read(master.key*)", "Edit(master.key*)", "Write(master.key*)", "Bash(*:master.key*)",
+      "Read(**/master.key*)", "Edit(**/master.key*)", "Write(**/master.key*)", "Bash(*:**/master.key*)",
+
+      "_description: 特定のディレクトリ以下の操作を全て禁止",
+      "Read(~/.aws/**)", "Edit(~/.aws/**)", "Write(~/.aws/**)", "Bash(*:~/.aws/**)",
+      "Read(**/.aws/**)", "Edit(**/.aws/**)", "Write(**/.aws/**)", "Bash(*:**/.aws/**)",
+      "Read(~/.ssh/**)", "Edit(~/.ssh/**)", "Write(~/.ssh/**)", "Bash(*:~/.ssh/**)",
+      "Read(**/.ssh/**)", "Edit(**/.ssh/**)", "Write(**/.ssh/**)", "Bash(*:**/.ssh/**)",
+      "Read(secrets/**)", "Edit(secrets/**)", "Write(secrets/**)", "Bash(*:secrets/**)",
+      "Read(**/secrets/**)", "Edit(**/secrets/**)", "Write(**/secrets/**)", "Bash(*:**/secrets/**)",
+      "Read(credentials/**)", "Edit(credentials/**)", "Write(credentials/**)", "Bash(*:credentials/**)",
+      "Read(**/credentials/**)", "Edit(**/credentials/**)", "Write(**/credentials/**)", "Bash(*:**/credentials/**)",
+      "Read(log/**)", "Edit(log/**)", "Write(log/**)", "Bash(*:log/**)",
+      "Read(**/log/**)", "Edit(**/log/**)", "Write(**/log/**)", "Bash(*:**/log/**)",
+      "Read(tmp/**)", "Edit(tmp/**)", "Write(tmp/**)", "Bash(*:tmp/**)",
+      "Read(**/tmp/**)", "Edit(**/tmp/**)", "Write(**/tmp/**)", "Bash(*:**/tmp/**)",
+      "Read(.git/**)", "Edit(.git/**)", "Write(.git/**)", "Bash(*:.git/**)",
+      "Read(**/.git/**)", "Edit(**/.git/**)", "Write(**/.git/**)", "Bash(*:**/.git/**)",
+
+      "Bash(sudo:*)",
+      "Bash(rm -rf:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(nc:*)",
+      "Write(.aws_config)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,7 +57,7 @@
       "Bash(curl:*)",
       "Bash(wget:*)",
       "Bash(nc:*)",
-      "Bash(chown:*)",
+      "Bash(chown:*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,7 +57,6 @@
       "Bash(curl:*)",
       "Bash(wget:*)",
       "Bash(nc:*)",
-      "Write(.aws_config)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,1 @@
+/Users/hisahiro.tsukamoto/github/hihats/dotfiles/.claude/settings.json

--- a/makesymlink.sh
+++ b/makesymlink.sh
@@ -11,3 +11,4 @@ ln -sf ~/github/hihats/dotfiles/.gitconfig ~/.gitconfig
 ln -sf ~/github/hihats/dotfiles/.gitignore_global ~/.gitignore_global
 ln -sf ~/github/hihats/dotfiles/.finicky.js ~/.finicky.js
 ln -sf ~/github/hihats/dotfiles/.npmrc ~/.npmrc
+ln -sf ~/github/hihats/dotfiles/.claude/settings.json ~/.claude/settings.json


### PR DESCRIPTION
## Summary
- Adds symlink creation for `.claude/settings.json` to the makesymlink.sh script
- Ensures Claude Code settings are properly managed with other dotfiles

## Test plan
- [x] Verify makesymlink.sh runs without errors
- [x] Confirm symlink is created correctly in ~/.claude/settings.json

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds automatic setup for Claude via a bundled settings file, simplifying initial configuration and onboarding.
  * Provides a default Claude permissions profile that enables common tasks while blocking access to sensitive files, directories, and privileged commands.
* **Chores**
  * Integrates the new settings into the existing dotfile setup without other behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->