### PR TITLE
~/.claude/CLAUDE.md を AGENTS.md へのシンボリックリンクに変更

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,2 +1,6 @@
 # CLAUDE.md
+
+<!-- NOTE: @AGENTS.md does not work in the user-global CLAUDE.md (~/.claude/CLAUDE.md).
+     In practice, this file is symlinked to ~/.agents/AGENTS.md via makesymlink.sh,
+     so the AGENTS.md content is served directly as CLAUDE.md. -->
 @AGENTS.md

--- a/makesymlink.sh
+++ b/makesymlink.sh
@@ -12,7 +12,9 @@ ln -sf ~/github/hihats/dotfiles/.gitignore_global ~/.gitignore_global
 ln -sf ~/github/hihats/dotfiles/.finicky.js ~/.finicky.js
 ln -sf ~/github/hihats/dotfiles/.npmrc ~/.npmrc
 ln -sf ~/github/hihats/dotfiles/.claude/settings.json ~/.claude/settings.json
-ln -sf ~/github/hihats/dotfiles/.claude/CLAUDE.md ~/.claude/CLAUDE.md
+mkdir -p ~/.agents
+ln -sf ~/github/hihats/dotfiles/.agents/AGENTS.md ~/.agents/AGENTS.md
+ln -sf ~/.agents/AGENTS.md ~/.claude/CLAUDE.md
 
 # Neovim
 mkdir -p ~/.config


### PR DESCRIPTION
   ユーザーグローバルの CLAUDE.md では @AGENTS.md 参照が機能しないため、
   makesymlink.sh でシンボリックリンク経由で内容を提供する運用に切り替え

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file setup to properly serve agent definitions through the system configuration directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->